### PR TITLE
[WAC-96] 지역 상세 페이지 API 연동

### DIFF
--- a/src/pages/regions/[id].vue
+++ b/src/pages/regions/[id].vue
@@ -1,26 +1,30 @@
+<script lang="ts" setup>
+interface RegionResponse {
+  id: number;
+  name: string;
+  description: string;
+  mainImage: string;
+}
+const { data: region } = await useFetch<RegionResponse>(
+  'http://localhost:8080/api/v1/regions/1',
+);
+</script>
+
 <template>
   <div class="regions-show">
     <div class="region-detail">
       <div class="image-wrapper">
-        <img
-          alt="지역 사진"
-          src="https://media.istockphoto.com/id/1257892405/ko/%EC%82%AC%EC%A7%84/%EC%84%9C%EC%9A%B8%EC%8B%9C%EC%9D%98-%EC%8A%A4%EC%B9%B4%EC%9D%B4%EB%9D%BC%EC%9D%B8%EA%B3%BC-%EC%8B%9C%EB%82%B4-%EB%A7%88%EC%B2%9C%EB%A3%A8%EB%8A%94-%EB%82%A8%ED%95%9C%EC%82%B0%EC%82%B0%EC%97%90%EC%84%9C-%EB%8C%80%ED%95%9C%EB%AF%BC%EA%B5%AD-%EC%B5%9C%EA%B3%A0%EC%9D%98-%EA%B2%BD%EC%B9%98%EC%99%80-%EC%95%84%EB%A6%84%EB%8B%A4%EC%9A%B4-%EA%B2%BD%EA%B4%80%EC%9E%85%EB%8B%88%EB%8B%A4.jpg?s=612x612&w=0&k=20&c=FkJTDCjvNOUDStG9_YotvlgHmxd2Ga7y8WY3O6BblfI="
-        />
+        <img :src="region?.mainImage" alt="지역 사진" />
       </div>
       <div class="info">
-        <h1 class="title">서울특별시</h1>
+        <h1 class="title">{{ region?.name }}</h1>
         <p class="description">
-          북쪽으로 한라산 정상부인 백록담을 경계로 제주시, 동쪽과 서쪽 및
-          남쪽으로 동중국해에 면한다. 12동, 3읍, 2면으로 이루어져 있고 서귀포시
-          중앙로 308번지(서홍동 440-1)에 제1청사가, 서귀포시 시청로
-          73번지(법환동 731)에 제2청사가 있다.
+          {{ region?.description }}
         </p>
       </div>
     </div>
   </div>
 </template>
-
-<script lang="ts" setup></script>
 
 <style lang="scss" scoped>
 .regions-show {


### PR DESCRIPTION
## 배경
- 지역 상세 페이지의 데이터를 백엔드에서 받아서, 프론트에서 사용자에게 UI로 제공해줘야 합니다.

## 작업내용
- API 연동 작업

## 기타 사항
- 테스트 코드 미 작성
- type을 어떻게 관리할지 아직 정하지 않음.
- nuxt3의 기본 설정인 useFetch를 사용하는데 baseURL을 어떻게 관리할지 아직 정하지 않음.