### PR TITLE
[WAC-97] 메인 페이지 API 연동

### DIFF
--- a/src/assets/styles/reset.scss
+++ b/src/assets/styles/reset.scss
@@ -8,3 +8,8 @@ body {
     margin: 0;
     padding: 0;
 }
+
+a {
+    text-decoration: none;
+    color: inherit;
+}

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -15,6 +15,7 @@ const { data: regions } = await useFetch<RegionResponse[]>(
     <div class="region-cards">
       <NuxtLink
         v-for="region in regions"
+        :key="region.id"
         :style="{ backgroundImage: `url(${region.thumbnailImage})` }"
         :to="`/regions/${region.id}`"
         class="region-card"

--- a/src/pages/index.vue
+++ b/src/pages/index.vue
@@ -1,54 +1,26 @@
-<script lang="ts" setup></script>
+<script lang="ts" setup>
+interface RegionResponse {
+  id: number;
+  name: string;
+  thumbnailImage: string;
+}
+const { data: regions } = await useFetch<RegionResponse[]>(
+  'http://localhost:8080/api/v1/regions',
+);
+</script>
 
 <template>
   <div class="index-wrapper">
     <h1>✨ 이런 곳에서 일해보면 어때요?</h1>
     <div class="region-cards">
-      <div class="region-card">
-        <h2 class="title">서울</h2>
-      </div>
-      <div class="region-card">
-        <h2 class="title">서울</h2>
-      </div>
-      <div class="region-card">
-        <h2 class="title">서울</h2>
-      </div>
-      <div class="region-card">
-        <h2 class="title">서울</h2>
-      </div>
-      <div class="region-card">
-        <h2 class="title">서울</h2>
-      </div>
-      <div class="region-card">
-        <h2 class="title">서울</h2>
-      </div>
-      <div class="region-card">
-        <h2 class="title">서울</h2>
-      </div>
-      <div class="region-card">
-        <h2 class="title">서울</h2>
-      </div>
-      <div class="region-card">
-        <h2 class="title">서울</h2>
-      </div>
-      <div class="region-card">
-        <h2 class="title">서울</h2>
-      </div>
-      <div class="region-card">
-        <h2 class="title">서울</h2>
-      </div>
-      <div class="region-card">
-        <h2 class="title">서울</h2>
-      </div>
-      <div class="region-card">
-        <h2 class="title">서울</h2>
-      </div>
-      <div class="region-card">
-        <h2 class="title">서울</h2>
-      </div>
-      <div class="region-card">
-        <h2 class="title">서울</h2>
-      </div>
+      <NuxtLink
+        v-for="region in regions"
+        :style="{ backgroundImage: `url(${region.thumbnailImage})` }"
+        :to="`/regions/${region.id}`"
+        class="region-card"
+      >
+        <h2 class="title">{{ region.name }}</h2>
+      </NuxtLink>
     </div>
   </div>
 </template>
@@ -79,7 +51,6 @@
     .region-card {
       height: 245px;
       border-radius: 16px;
-      background-image: url('https://media.istockphoto.com/id/1257892405/ko/%EC%82%AC%EC%A7%84/%EC%84%9C%EC%9A%B8%EC%8B%9C%EC%9D%98-%EC%8A%A4%EC%B9%B4%EC%9D%B4%EB%9D%BC%EC%9D%B8%EA%B3%BC-%EC%8B%9C%EB%82%B4-%EB%A7%88%EC%B2%9C%EB%A3%A8%EB%8A%94-%EB%82%A8%ED%95%9C%EC%82%B0%EC%82%B0%EC%97%90%EC%84%9C-%EB%8C%80%ED%95%9C%EB%AF%BC%EA%B5%AD-%EC%B5%9C%EA%B3%A0%EC%9D%98-%EA%B2%BD%EC%B9%98%EC%99%80-%EC%95%84%EB%A6%84%EB%8B%A4%EC%9A%B4-%EA%B2%BD%EA%B4%80%EC%9E%85%EB%8B%88%EB%8B%A4.jpg?s=612x612&w=0&k=20&c=FkJTDCjvNOUDStG9_YotvlgHmxd2Ga7y8WY3O6BblfI=');
       background-size: cover;
       display: flex;
       align-items: flex-end;

--- a/src/pages/regions/[id].vue
+++ b/src/pages/regions/[id].vue
@@ -1,12 +1,17 @@
 <script lang="ts" setup>
+import { useRoute } from 'vue-router';
+
 interface RegionResponse {
   id: number;
   name: string;
   description: string;
   mainImage: string;
 }
+
+const route = useRoute();
+
 const { data: region } = await useFetch<RegionResponse>(
-  'http://localhost:8080/api/v1/regions/1',
+  `http://localhost:8080/api/v1/regions/${route.params.id}`,
 );
 </script>
 


### PR DESCRIPTION
## 배경
- 메인 페이지 API 연동

## 작업 내용
- 메인 페이지 API 연동
- 상세 페이지 API 연동의 ID 동적데이터를 사용하지 않은 것 처리
- a링크 reset 추가

## 기타사항
- 테스트 코드 작성하지 않음.
- type, api 분리 작업을 하지 않음.
- baseURL 처리를 아직 하지 않음.